### PR TITLE
Fix PNG symlink

### DIFF
--- a/testing/message-mail-new.png
+++ b/testing/message-mail-new.png
@@ -1,1 +1,1 @@
-../src/chrome/skin/mail-unread.png
+../src/chrome/skin/icons/img/mail-unread.png


### PR DESCRIPTION
The source moved in 639bf7a and 9afa777.
