### PR TITLE
Bring window to front when restored

### DIFF
--- a/src/modules/winnt/FiretrayWindow.jsm
+++ b/src/modules/winnt/FiretrayWindow.jsm
@@ -53,6 +53,7 @@ firetray.Window.setVisibility = function(wid, visible) {
   let hwnd = firetray.Win32.hexStrToHwnd(wid);
   let ret = user32.ShowWindow(hwnd, visible ? user32.SW_SHOW : user32.SW_HIDE);
   log.debug("  ShowWindow="+ret+" winLastError="+ctypes.winLastError);
+  if (visible) user32.SetForegroundWindow(hwnd);
 };
 
 firetray.Window.wndProc = function(hWnd, uMsg, wParam, lParam) { // filterWindow


### PR DESCRIPTION
When window is restored and another window is on top then the Thunderbird window is in background. This fix will bring it on the top level so the user may access it immediately.